### PR TITLE
Update cli import path

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 type CLI struct {

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"testing"
 )
 


### PR DESCRIPTION
The location of the imported cli package has moved from `codegangsta` to `urfave`. Go modules cannot import this package as is and returns the following error:

```
github.com/zpatrick/go-config imports
github.com/codegangsta/cli: github.com/codegangsta/cli@v1.22.1: parsing go.mod:
module declares its path as: github.com/urfave/cli
        but was required as: github.com/codegangsta/cli
```

Updating the import to the new location resolves this issue.