### PR TITLE
Fix the error. cli_test.go can't pass the test. issue #9

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -19,16 +20,6 @@ func NewCLI(context *cli.Context, useDefaults bool) *CLI {
 
 func (this *CLI) Load() (map[string]string, error) {
 	settings := map[string]string{}
-
-	for _, flag := range this.context.GlobalFlagNames() {
-		val := fmt.Sprintf("%v", this.context.GlobalGeneric(flag))
-
-		if this.context.GlobalIsSet(flag) {
-			settings[flag] = val
-		} else if this.useDefaults && val != "" {
-			settings[flag] = val
-		}
-	}
 
 	for _, flag := range this.context.FlagNames() {
 		val := fmt.Sprintf("%v", this.context.Generic(flag))

--- a/cli_test.go
+++ b/cli_test.go
@@ -38,8 +38,7 @@ func TestCLILoad(t *testing.T) {
 
 		actualSettings, err := cliProvider.Load()
 		if err != nil {
-			t.Error(err)
-			return err
+			t.Fatal(err)
 		}
 
 		for key, expected := range expectedSettings {

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/urfave/cli"
 	"testing"
+
+	"github.com/urfave/cli"
 )
 
 func TestCLILoad(t *testing.T) {
@@ -10,21 +11,21 @@ func TestCLILoad(t *testing.T) {
 
 	app := cli.NewApp()
 	app.Flags = []cli.Flag{
-		cli.IntFlag{
+		&cli.IntFlag{
 			Name: "timeout",
 		},
-		cli.Float64Flag{
+		&cli.Float64Flag{
 			Name: "frequency",
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name: "time_zone",
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name: "enabled",
 		},
 	}
 
-	app.Action = func(c *cli.Context) {
+	app.Action = func(c *cli.Context) error {
 		executed = true
 		cliProvider := NewCLI(c, false)
 
@@ -38,6 +39,7 @@ func TestCLILoad(t *testing.T) {
 		actualSettings, err := cliProvider.Load()
 		if err != nil {
 			t.Error(err)
+			return err
 		}
 
 		for key, expected := range expectedSettings {
@@ -51,6 +53,7 @@ func TestCLILoad(t *testing.T) {
 				t.Errorf("Setting '%s' was '%s', expected '%s'", key, actual, expected)
 			}
 		}
+		return err
 	}
 
 	app.Run(


### PR DESCRIPTION
The library `/urfave/cli` has adjusted some definition of struct and method names. I list the changes that violate the success of `cli.go` test below:

 
context.GlobalGeneric method has changed to `GlobalFlagNames()`  
context.GlobalGeneric method has changed to `Generic()`  
context.GlobalIsSet() method has changed to `IsSet()`  
cli.ActionFunc has changed from `func(*Context)` to `func(*Context) error`  

And this solution can close the issue #9. Hope this is helpful.
